### PR TITLE
アプリ名をvoicenotelmに変更 #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# expo-poc
+# voicenotelm
 
 Expo を使用したモバイルアプリの PoC プロジェクトです。
 

--- a/app.json
+++ b/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
-    "name": "expo-poc",
-    "slug": "expo-poc",
+    "name": "voicenotelm",
+    "slug": "voicenotelm",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "expopoc",
+    "scheme": "voicenotelm",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "expo-poc",
+  "name": "voicenotelm",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "expo-poc",
+      "name": "voicenotelm",
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "expo-poc",
+  "name": "voicenotelm",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {


### PR DESCRIPTION
## 関連 Issue

Closes #41 

## やったこと
- アプリ名の反映
app.jsonのexpo.name/expo.slug/expo.schemeをvoicenotelmに変更

- リポジトリ表記の統一
package.json の name をvoicenotelmに変更
package-lock.json のルートnameをvoicenotelmに変更
README.md のタイトルをvoicenotelmに変更

- 変更してないところ
bundleId/packageとかはGoogle consoleとかfirebase関連に支障出そう？な気がしたので変更してないです。

## 追加したライブラリ、パッケージ
なし

## 動作確認

- [ ] ビルドできた

## 参考にした資料

<!-- I want to review in Japanese. -->
<!-- 日本語でレビューしてください -->

#### レビューの接頭語

[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報
