### PR TITLE
メモ詳細画面フォルダー情報追加 #103

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "voicenotelm",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",

--- a/src/features/notes/note-content/MarkdownEditor.tsx
+++ b/src/features/notes/note-content/MarkdownEditor.tsx
@@ -1,0 +1,51 @@
+import { colors } from '@/src/shared/constants';
+import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { TextInput } from 'react-native';
+
+interface MarkdownEditorProps {
+  value: string;
+  onChangeText: (text: string) => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+}
+
+export interface MarkdownEditorRef {
+  focus: () => void;
+  blur: () => void;
+}
+
+export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>(
+  ({ value, onChangeText, onBlur, placeholder, autoFocus }, ref) => {
+    const inputRef = useRef<TextInput>(null);
+
+    useImperativeHandle(ref, () => ({
+      focus: () => inputRef.current?.focus(),
+      blur: () => inputRef.current?.blur(),
+    }));
+
+    return (
+      <TextInput
+        ref={inputRef}
+        value={value}
+        onChangeText={onChangeText}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        placeholderTextColor={colors.text.tertiary}
+        multiline
+        autoFocus={autoFocus}
+        style={{
+          flex: 1,
+          fontSize: 16,
+          lineHeight: 24,
+          color: colors.text.primary,
+          minHeight: 200,
+          textAlignVertical: 'top',
+          padding: 12,
+        }}
+      />
+    );
+  }
+);
+
+MarkdownEditor.displayName = 'MarkdownEditor';

--- a/src/features/notes/note-content/NoteContent.tsx
+++ b/src/features/notes/note-content/NoteContent.tsx
@@ -1,6 +1,11 @@
 import { colors } from '@/src/shared/constants';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useCallback, useRef, useState } from 'react';
+import { TouchableOpacity, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { Surface, Text } from 'react-native-paper';
+
+import { MarkdownEditor, type MarkdownEditorRef } from './MarkdownEditor';
 
 // スタイル
 const markdownStyles = {
@@ -51,20 +56,79 @@ const markdownStyles = {
 
 // 型定義
 interface NoteContentProps {
-  content: string;
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => Promise<void> | void;
   transcription?: string;
   showTranscription: boolean;
+  editable?: boolean;
 }
 
 // コンポーネント
-export function NoteContent({ content, transcription, showTranscription }: NoteContentProps) {
+export function NoteContent({
+  value,
+  onChange,
+  onBlur,
+  transcription,
+  showTranscription,
+  editable = false,
+}: NoteContentProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const editorRef = useRef<MarkdownEditorRef>(null);
+
+  const handlePress = useCallback(() => {
+    if (editable) {
+      setIsEditing(true);
+    }
+  }, [editable]);
+
+  const handleBlur = useCallback(async () => {
+    if (onBlur) {
+      await onBlur();
+    }
+    setIsEditing(false);
+  }, [onBlur]);
+
+  // 編集モード
+  if (isEditing && editable) {
+    return (
+      <Surface className="bg-t-bg-primary rounded-xl p-1" elevation={0}>
+        {/* 表示モードの鉛筆アイコン行と同じ高さのスペーサー */}
+        <View className="flex-row items-center justify-end px-2 pt-1 h-5" />
+        <MarkdownEditor
+          ref={editorRef}
+          value={value}
+          onChangeText={onChange}
+          onBlur={handleBlur}
+          placeholder="メモを入力..."
+          autoFocus
+        />
+      </Surface>
+    );
+  }
+
+  // 表示モード
   return (
-    <Surface className="bg-t-bg-primary rounded-xl p-1" elevation={0}>
-      {showTranscription && transcription ? (
-        <Text className="text-t-text-primary text-base leading-6 p-2">{transcription}</Text>
-      ) : (
-        <Markdown style={markdownStyles}>{content}</Markdown>
-      )}
-    </Surface>
+    <TouchableOpacity onPress={handlePress} activeOpacity={editable ? 0.7 : 1} disabled={!editable}>
+      <Surface className="bg-t-bg-primary rounded-xl p-1" elevation={0}>
+        {/* 編集可能ヒント */}
+        {editable && (
+          <View className="flex-row items-center justify-end px-2 pt-1">
+            <MaterialCommunityIcons
+              name="pencil-outline"
+              size={14}
+              color={colors.text.tertiary}
+              style={{ opacity: 0.5 }}
+            />
+          </View>
+        )}
+
+        {showTranscription && transcription ? (
+          <Text className="text-t-text-primary text-base leading-6 p-2">{transcription}</Text>
+        ) : (
+          <Markdown style={markdownStyles}>{value || 'メモをタップして編集...'}</Markdown>
+        )}
+      </Surface>
+    </TouchableOpacity>
   );
 }

--- a/src/features/notes/note-content/index.ts
+++ b/src/features/notes/note-content/index.ts
@@ -1,1 +1,2 @@
 export { NoteContent } from './NoteContent';
+export { MarkdownEditor, type MarkdownEditorRef } from './MarkdownEditor';

--- a/src/features/notes/note-title/EditableTitle.tsx
+++ b/src/features/notes/note-title/EditableTitle.tsx
@@ -1,0 +1,73 @@
+import { colors } from '@/src/shared/constants';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useCallback, useState } from 'react';
+import { TextInput, TouchableOpacity, View } from 'react-native';
+import { Text } from 'react-native-paper';
+
+interface EditableTitleProps {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => Promise<void>;
+}
+
+export function EditableTitle({ value, onChange, onBlur }: EditableTitleProps) {
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handlePress = useCallback(() => {
+    setIsEditing(true);
+  }, []);
+
+  const handleBlur = useCallback(async () => {
+    if (onBlur) {
+      await onBlur();
+    }
+    setIsEditing(false);
+  }, [onBlur]);
+
+  const displayTitle = value || '無題のメモ';
+
+  if (isEditing) {
+    return (
+      <View className="flex-row items-center mb-2">
+        <TextInput
+          value={value}
+          onChangeText={onChange}
+          onBlur={handleBlur}
+          autoFocus
+          maxLength={100}
+          placeholder="タイトルを入力"
+          placeholderTextColor={colors.text.tertiary}
+          style={{
+            flex: 1,
+            fontSize: 22,
+            fontWeight: '600',
+            color: colors.text.primary,
+            padding: 0,
+          }}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      className="flex-row items-center mb-2"
+      activeOpacity={0.7}
+    >
+      <Text
+        variant="titleLarge"
+        className="font-semibold text-t-text-primary flex-1"
+        numberOfLines={2}
+      >
+        {displayTitle}
+      </Text>
+      <MaterialCommunityIcons
+        name="pencil-outline"
+        size={18}
+        color={colors.text.tertiary}
+        style={{ marginLeft: 8, opacity: 0.6 }}
+      />
+    </TouchableOpacity>
+  );
+}

--- a/src/features/notes/note-title/index.ts
+++ b/src/features/notes/note-title/index.ts
@@ -1,0 +1,1 @@
+export { EditableTitle } from './EditableTitle';

--- a/src/features/notes/shared/index.ts
+++ b/src/features/notes/shared/index.ts
@@ -1,0 +1,1 @@
+export { useDebouncedSave } from './useDebouncedSave';

--- a/src/features/notes/shared/useDebouncedSave.ts
+++ b/src/features/notes/shared/useDebouncedSave.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseDebouncedSaveOptions {
+  value: string;
+  initialValue: string; // APIから取得した初期値（これが変わった時のみlastSavedValueをリセット）
+  delay?: number; // デフォルト: 1000ms
+  onSave: (value: string) => Promise<void>;
+}
+
+interface UseDebouncedSaveResult {
+  isSaving: boolean;
+  isDirty: boolean;
+  flush: () => Promise<void>;
+}
+
+/**
+ * Controlled Componentパターン用のdebounce付き自動保存フック
+ *
+ * 外部から value と initialValue を受け取り、変更があると delay ms 後に自動保存される
+ * - value: 現在の値（外部で管理）
+ * - initialValue: APIから取得した初期値（これが変わった時のみlastSavedValueをリセット）
+ * - onSave: 保存処理
+ * - flush: 即座に保存（blur時など）
+ * - isDirty: 未保存の変更があるか
+ */
+export function useDebouncedSave({
+  value,
+  initialValue,
+  delay = 1000,
+  onSave,
+}: UseDebouncedSaveOptions): UseDebouncedSaveResult {
+  const [isSaving, setIsSaving] = useState(false);
+
+  // 最後に保存した値を追跡（不要な保存を避けるため）
+  const lastSavedValueRef = useRef(initialValue);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingValueRef = useRef<string | null>(null);
+  const onSaveRef = useRef(onSave);
+
+  // onSaveの参照を常に最新に保つ
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  }, [onSave]);
+
+  // 外部の initialValue が変わった場合（別メモへの遷移など）にリセット
+  useEffect(() => {
+    // 保存中でなく、かつ pending がない場合のみリセット
+    if (!isSaving && pendingValueRef.current === null) {
+      lastSavedValueRef.current = initialValue;
+    }
+  }, [initialValue, isSaving]);
+
+  // isDirtyの計算
+  const isDirty = value !== lastSavedValueRef.current;
+
+  // 保存処理
+  const save = useCallback(async (valueToSave: string) => {
+    if (valueToSave === lastSavedValueRef.current) {
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onSaveRef.current(valueToSave);
+      lastSavedValueRef.current = valueToSave;
+    } finally {
+      setIsSaving(false);
+    }
+  }, []);
+
+  // 値が変更された時にdebounceタイマーをセット
+  useEffect(() => {
+    // 初回レンダリングや外部リセット時はスキップ
+    if (value === lastSavedValueRef.current) {
+      return;
+    }
+
+    pendingValueRef.current = value;
+
+    // 既存のタイマーをクリア
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    // 新しいタイマーをセット
+    timeoutRef.current = setTimeout(() => {
+      if (pendingValueRef.current !== null) {
+        save(pendingValueRef.current);
+        pendingValueRef.current = null;
+      }
+    }, delay);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [value, delay, save]);
+
+  // 即座に保存（blur時など）
+  const flush = useCallback(async () => {
+    // タイマーをキャンセル
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    // 現在の値と最後に保存した値が異なる場合は保存
+    if (pendingValueRef.current !== null) {
+      await save(pendingValueRef.current);
+      pendingValueRef.current = null;
+    }
+  }, [save]);
+
+  // クリーンアップ
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    isSaving,
+    isDirty,
+    flush,
+  };
+}


### PR DESCRIPTION
メモ詳細画面にタイトルとコンテンツの編集機能を追加し、自動保存を実装。Markdownエディタを新規作成し、関連コンポーネントを統合。

## 関連 Issue

Closes #103 

## やったこと

## 追加したライブラリ、パッケージ

## 動作確認

- [ ] ビルドできた

## 参考にした資料

<!-- I want to review in Japanese. -->
<!-- 日本語でレビューしてください -->

#### レビューの接頭語

[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報
