### PR TITLE
設定画面プロフィール取得、編集、ログアウト #128

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,6 +8,7 @@ import {
   noteDetailScreenOptions,
   recordScreenOptions,
   searchScreenOptions,
+  settingsScreenOptions,
 } from '@/src/navigation/screen-options';
 import { ProcessingToast } from '@/src/shared/components';
 import { colors } from '@/src/shared/constants';
@@ -39,6 +40,7 @@ export default function RootLayout() {
               <Stack.Screen name="search" options={searchScreenOptions} />
               <Stack.Screen name="note/[id]" options={noteDetailScreenOptions} />
               <Stack.Screen name="record" options={recordScreenOptions} />
+              <Stack.Screen name="settings" options={settingsScreenOptions} />
             </Stack>
             <ProcessingToast />
           </View>

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,5 @@
+import { SettingsScreen } from '@/src/features/settings';
+
+export default function SettingsPage() {
+  return <SettingsScreen />;
+}

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -7,6 +7,7 @@ import {
   TagsResponse,
   TokenResponse,
   UpdateMemoRequest,
+  UserResponse,
 } from './generated/apiSchema';
 import { setupAxiosInterceptors } from './interceptors';
 import { useAuthStore } from '@/src/shared/stores/authStore';
@@ -150,6 +151,18 @@ class ApiClient {
     }
 
     const response = await this.api.api.formatMemo({ transcription, language }, { secure: true });
+    return response.data;
+  }
+
+  /**
+   * プロフィールを更新
+   */
+  async updateProfile(data: { name: string }): Promise<UserResponse> {
+    const response = await this.api.instance.patch<UserResponse>('/api/profile', data, {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+    });
     return response.data;
   }
 }

--- a/src/features/settings/EditNameDialog.tsx
+++ b/src/features/settings/EditNameDialog.tsx
@@ -1,0 +1,149 @@
+import { useState, useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import { Button, Dialog, Portal, Text, TextInput } from 'react-native-paper';
+
+import { colors } from '@/src/shared/constants';
+
+interface EditNameDialogProps {
+  visible: boolean;
+  currentName: string;
+  onSave: (newName: string) => Promise<void>;
+  onCancel: () => void;
+  isSaving: boolean;
+}
+
+/**
+ * 名前編集ダイアログ
+ */
+export function EditNameDialog({
+  visible,
+  currentName,
+  onSave,
+  onCancel,
+  isSaving,
+}: EditNameDialogProps) {
+  const [name, setName] = useState(currentName);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (visible) {
+      setName(currentName);
+      setError('');
+    }
+  }, [visible, currentName]);
+
+  const handleSave = async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError('名前を入力してください');
+      return;
+    }
+    if (trimmedName === currentName) {
+      onCancel();
+      return;
+    }
+    try {
+      await onSave(trimmedName);
+    } catch {
+      setError('保存に失敗しました');
+    }
+  };
+
+  const handleCancel = () => {
+    setName(currentName);
+    setError('');
+    onCancel();
+  };
+
+  return (
+    <Portal>
+      <Dialog visible={visible} onDismiss={handleCancel} style={styles.dialog}>
+        <Dialog.Title style={styles.title}>名前を編集</Dialog.Title>
+        <Dialog.Content>
+          <TextInput
+            value={name}
+            onChangeText={(text) => {
+              setName(text);
+              setError('');
+            }}
+            mode="outlined"
+            placeholder="名前を入力"
+            autoFocus
+            style={styles.input}
+            outlineColor={colors.border.primary}
+            activeOutlineColor={colors.brand[600]}
+            error={!!error}
+          />
+          {error ? <Text style={styles.errorText}>{error}</Text> : null}
+        </Dialog.Content>
+        <Dialog.Actions style={styles.actions}>
+          <Button
+            onPress={handleCancel}
+            mode="outlined"
+            style={styles.cancelButton}
+            labelStyle={styles.cancelButtonLabel}
+            disabled={isSaving}
+          >
+            キャンセル
+          </Button>
+          <Button
+            onPress={handleSave}
+            mode="contained"
+            style={styles.saveButton}
+            buttonColor={colors.brand[600]}
+            labelStyle={styles.saveButtonLabel}
+            loading={isSaving}
+            disabled={isSaving}
+          >
+            保存
+          </Button>
+        </Dialog.Actions>
+      </Dialog>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  dialog: {
+    backgroundColor: colors.bg.primary,
+    borderRadius: 16,
+    marginHorizontal: 24,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  input: {
+    backgroundColor: colors.bg.primary,
+  },
+  errorText: {
+    color: colors.danger[600],
+    fontSize: 12,
+    marginTop: 4,
+  },
+  actions: {
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+    gap: 8,
+  },
+  cancelButton: {
+    borderColor: colors.border.primary,
+    borderRadius: 8,
+    flex: 1,
+  },
+  cancelButtonLabel: {
+    color: colors.text.primary,
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  saveButton: {
+    borderRadius: 8,
+    flex: 1,
+  },
+  saveButtonLabel: {
+    color: colors.text.inverse,
+    fontSize: 14,
+    fontWeight: '500',
+  },
+});

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -1,0 +1,208 @@
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { Divider, Text, TouchableRipple } from 'react-native-paper';
+
+import { EditNameDialog } from './EditNameDialog';
+import { apiClient } from '@/src/api';
+import { ConfirmDialog } from '@/src/shared/components';
+import { colors } from '@/src/shared/constants';
+import { useAuthStore } from '@/src/shared/stores/authStore';
+
+/**
+ * 設定画面
+ *
+ * プロフィール表示、名前編集、ログアウト機能を提供
+ */
+export function SettingsScreen() {
+  const { user, logout, refreshToken, setUser } = useAuthStore();
+  const [isEditNameDialogVisible, setEditNameDialogVisible] = useState(false);
+  const [isLogoutDialogVisible, setLogoutDialogVisible] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleEditName = () => {
+    setEditNameDialogVisible(true);
+  };
+
+  const handleSaveName = async (newName: string) => {
+    setIsSaving(true);
+    try {
+      const updatedUser = await apiClient.updateProfile({ name: newName });
+      setUser(updatedUser);
+      setEditNameDialogVisible(false);
+    } catch (error) {
+      if (__DEV__) {
+        console.error('Failed to update profile:', error);
+      }
+      throw error;
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleLogoutPress = () => {
+    setLogoutDialogVisible(true);
+  };
+
+  const handleLogoutConfirm = async () => {
+    setLogoutDialogVisible(false);
+    try {
+      if (refreshToken) {
+        await apiClient.logout(refreshToken);
+      }
+    } catch (error) {
+      if (__DEV__) {
+        console.error('Logout API call failed:', error);
+      }
+    }
+    logout();
+    router.replace('/login');
+  };
+
+  const handleLogoutCancel = () => {
+    setLogoutDialogVisible(false);
+  };
+
+  return (
+    <View className="flex-1 bg-t-bg-secondary">
+      <ScrollView className="flex-1" contentContainerStyle={styles.scrollContent}>
+        {/* プロフィールセクション */}
+        <View style={styles.section}>
+          <View style={styles.sectionContent}>
+            {/* 名前 */}
+            <TouchableRipple onPress={handleEditName} style={styles.item}>
+              <View style={styles.itemContent}>
+                <View style={styles.itemLeft}>
+                  <Text style={styles.itemLabel}>名前</Text>
+                  <Text style={styles.itemValue}>{user?.name || '-'}</Text>
+                </View>
+                <View style={styles.editButton}>
+                  <Text style={styles.editButtonText}>編集</Text>
+                </View>
+              </View>
+            </TouchableRipple>
+
+            <Divider style={styles.divider} />
+
+            {/* メールアドレス */}
+            <View style={styles.item}>
+              <View style={styles.itemContent}>
+                <View style={styles.itemLeft}>
+                  <Text style={styles.itemLabel}>メールアドレス</Text>
+                  <Text style={styles.itemValue}>{user?.email || '-'}</Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+
+        {/* ログアウトボタン */}
+        <View style={styles.section}>
+          <TouchableRipple onPress={handleLogoutPress} style={styles.logoutButton}>
+            <View style={styles.logoutButtonContent}>
+              <MaterialCommunityIcons
+                name="logout"
+                size={20}
+                color={colors.danger[600]}
+                style={styles.logoutIcon}
+              />
+              <Text style={styles.logoutButtonText}>ログアウト</Text>
+            </View>
+          </TouchableRipple>
+        </View>
+      </ScrollView>
+
+      {/* 名前編集ダイアログ */}
+      <EditNameDialog
+        visible={isEditNameDialogVisible}
+        currentName={user?.name || ''}
+        onSave={handleSaveName}
+        onCancel={() => setEditNameDialogVisible(false)}
+        isSaving={isSaving}
+      />
+
+      {/* ログアウト確認ダイアログ */}
+      <ConfirmDialog
+        visible={isLogoutDialogVisible}
+        title="ログアウトしますか？"
+        message="再度ログインすることで、メモを閲覧できます。"
+        confirmText="ログアウト"
+        cancelText="キャンセル"
+        variant="danger"
+        onConfirm={handleLogoutConfirm}
+        onCancel={handleLogoutCancel}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    paddingVertical: 16,
+  },
+  section: {
+    marginBottom: 16,
+    marginHorizontal: 16,
+  },
+  sectionContent: {
+    backgroundColor: colors.bg.primary,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  item: {
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+  },
+  itemContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  itemLeft: {
+    flex: 1,
+  },
+  itemLabel: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    marginBottom: 4,
+  },
+  itemValue: {
+    fontSize: 16,
+    color: colors.text.primary,
+  },
+  editButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+    backgroundColor: colors.bg.tertiary,
+  },
+  editButtonText: {
+    fontSize: 14,
+    color: colors.text.primary,
+    fontWeight: '500',
+  },
+  divider: {
+    backgroundColor: colors.border.primary,
+    marginHorizontal: 16,
+  },
+  logoutButton: {
+    backgroundColor: colors.bg.primary,
+    borderRadius: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+  },
+  logoutButtonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  logoutIcon: {
+    marginRight: 8,
+  },
+  logoutButtonText: {
+    fontSize: 16,
+    color: colors.danger[600],
+    fontWeight: '500',
+  },
+});

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,0 +1,1 @@
+export { SettingsScreen } from './SettingsScreen';

--- a/src/navigation/screen-options.tsx
+++ b/src/navigation/screen-options.tsx
@@ -112,3 +112,10 @@ export const recordScreenOptions: NativeStackNavigationOptions = {
 export const searchScreenOptions: NativeStackNavigationOptions = {
   title: '検索',
 };
+
+/**
+ * settings画面のヘッダー設定
+ */
+export const settingsScreenOptions: NativeStackNavigationOptions = {
+  title: 'アカウント設定',
+};

--- a/src/shared/components/SettingsMenu.tsx
+++ b/src/shared/components/SettingsMenu.tsx
@@ -1,4 +1,5 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { router } from 'expo-router';
 import { StyleSheet, View } from 'react-native';
 import { Menu, TouchableRipple, Text, IconButton } from 'react-native-paper';
 
@@ -30,16 +31,18 @@ export function SettingsMenu({ tintColor = '#000' }: SettingsMenuProps) {
     // 例: { icon: 'account', label: 'アカウント設定', onPress: () => {} },
   ];
 
-  // メニュー項目がない場合は歯車アイコンのみ表示（クリックしても何もしない）
+  const handleSettingsPress = () => {
+    router.push('/settings');
+  };
+
+  // メニュー項目がない場合は歯車アイコンのみ表示（設定画面へ遷移）
   if (menuItems.length === 0) {
     return (
       <IconButton
         icon="cog"
         iconColor={tintColor}
         size={24}
-        onPress={() => {
-          // TODO: 設定機能が追加されたらメニューを開く
-        }}
+        onPress={handleSettingsPress}
         accessibilityLabel="設定"
       />
     );


### PR DESCRIPTION
## 関連 Issue

Closes #128 

## やったこと
設定画面プロフィール取得、編集、ログアウトの部分を作りました

設定画面
<img width="1680" height="944" alt="image" src="https://github.com/user-attachments/assets/68aeeef3-4ad8-472f-b252-175814b9f6bd" />

ユーザーネーム変更画面
<img width="1680" height="944" alt="image" src="https://github.com/user-attachments/assets/ed543271-67b9-4219-bcd5-245e5d3b6ea7" />

ログアウトボタンを押したとき
<img width="1680" height="944" alt="image" src="https://github.com/user-attachments/assets/e8574230-8baa-42ff-8cbe-6295e6339d5d" />


## 追加したライブラリ、パッケージ

## 動作確認

- [ ] ビルドできた

## 参考にした資料

<!-- I want to review in Japanese. -->
<!-- 日本語でレビューしてください -->

#### レビューの接頭語

[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報
