### PR TITLE
要約内容の再要約する機能の追加 #80

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@/src/shared/stores/authStore';
 import {
   Api,
   FormatMemoResponse,
@@ -6,11 +7,11 @@ import {
   MemoDetailResponse,
   TagsResponse,
   TokenResponse,
+  TranscriptionResponse,
   UpdateMemoRequest,
   UserResponse,
 } from './generated/apiSchema';
 import { setupAxiosInterceptors } from './interceptors';
-import { useAuthStore } from '@/src/shared/stores/authStore';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL || 'http://localhost:8080';
 
@@ -119,6 +120,14 @@ class ApiClient {
   }
 
   /**
+   * 文字起こしテキストを取得
+   */
+  async getTranscription(memoId: string): Promise<TranscriptionResponse> {
+    const response = await this.api.api.getTranscription(memoId, { secure: true });
+    return response.data;
+  }
+
+  /**
    * メモを削除
    */
   async deleteMemo(memoId: string): Promise<void> {
@@ -130,6 +139,18 @@ class ApiClient {
    */
   async updateMemo(memoId: string, data: UpdateMemoRequest): Promise<MemoDetailResponse> {
     const response = await this.api.api.updateMemo(memoId, data, { secure: true });
+    return response.data;
+  }
+
+  /**
+   * 編集済み文字起こしで再AI整形
+   */
+  async resummarizeMemo(memoId: string, editedTranscription: string): Promise<MemoDetailResponse> {
+    const response = await this.api.api.resummarize(
+      memoId,
+      { editedTranscription },
+      { secure: true }
+    );
     return response.data;
   }
 

--- a/src/features/notes/NoteDetailScreen.tsx
+++ b/src/features/notes/NoteDetailScreen.tsx
@@ -405,6 +405,12 @@ export function NoteDetailScreen() {
     [initialTranscriptionText]
   );
 
+  const handleCloseTranscription = useCallback(() => {
+    setTranscriptionText(initialTranscriptionText);
+    setIsTranscriptionDirty(false);
+    setIsTranscriptionOpen(false);
+  }, [initialTranscriptionText]);
+
   const transcriptionLineHeight = 24;
   const transcriptionPadding = 12;
   const transcriptionLineCount = useMemo(
@@ -565,7 +571,7 @@ export function NoteDetailScreen() {
                     文字起こし
                   </Text>
                   <TouchableOpacity
-                    onPress={() => setIsTranscriptionOpen(false)}
+                    onPress={handleCloseTranscription}
                     className="flex-row items-center px-2 py-1"
                     accessibilityRole="button"
                     accessibilityLabel="文字起こしを閉じる"

--- a/src/features/notes/NoteDetailScreen.tsx
+++ b/src/features/notes/NoteDetailScreen.tsx
@@ -147,9 +147,6 @@ export function NoteDetailScreen() {
   const handleSaveTitle = useCallback(
     async (newTitle: string) => {
       if (!memo) return;
-      if (newTitle.trim() === '') {
-        return;
-      }
 
       const attemptSave = async (): Promise<void> => {
         try {
@@ -189,9 +186,6 @@ export function NoteDetailScreen() {
   const handleSaveContent = useCallback(
     async (newContent: string) => {
       if (!memo) return;
-      if (newContent.trim() === '') {
-        return;
-      }
 
       const attemptSave = async (): Promise<void> => {
         try {

--- a/src/features/notes/NoteDetailScreen.tsx
+++ b/src/features/notes/NoteDetailScreen.tsx
@@ -570,16 +570,6 @@ export function NoteDetailScreen() {
                   >
                     文字起こし
                   </Text>
-                  <TouchableOpacity
-                    onPress={handleCloseTranscription}
-                    className="flex-row items-center px-2 py-1"
-                    accessibilityRole="button"
-                    accessibilityLabel="文字起こしを閉じる"
-                  >
-                    <Text variant="bodySmall" style={{ color: colors.text.secondary }}>
-                      閉じる
-                    </Text>
-                  </TouchableOpacity>
                 </View>
                 <View className="bg-t-bg-primary border border-t-border-primary rounded-xl p-1">
                   {isTranscriptionLoading ? (
@@ -626,6 +616,18 @@ export function NoteDetailScreen() {
                     textColor={colors.text.inverse}
                   >
                     AIで再整形
+                  </Button>
+                </View>
+                <View className="mt-3">
+                  <Button
+                    mode="outlined"
+                    style={styles.secondaryButton}
+                    contentStyle={styles.secondaryButtonContent}
+                    labelStyle={styles.secondaryButtonLabel}
+                    onPress={handleCloseTranscription}
+                    textColor={colors.text.primary}
+                  >
+                    文字起こしを閉じる
                   </Button>
                 </View>
               </View>

--- a/src/features/notes/NoteDetailScreen.tsx
+++ b/src/features/notes/NoteDetailScreen.tsx
@@ -2,12 +2,13 @@ import { apiClient } from '@/src/api';
 import type { FormatMemoResponse, MemoDetailResponse } from '@/src/api/generated/apiSchema';
 import { ConfirmDialog } from '@/src/shared/components';
 import { colors } from '@/src/shared/constants';
+import { useProcessingStore } from '@/src/shared/stores/processingStore';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useHeaderHeight } from '@react-navigation/elements';
 import { router, useLocalSearchParams, useNavigation } from 'expo-router';
-import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
-import { Alert, ScrollView, TouchableOpacity, View } from 'react-native';
-import { ActivityIndicator, Text } from 'react-native-paper';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Alert, ScrollView, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Button, Text } from 'react-native-paper';
 
 import { NoteContent } from './note-content';
 import { TagSection } from './note-tags';
@@ -45,9 +46,12 @@ export function NoteDetailScreen() {
 
   // 録音後の直接遷移時はmemoDataからパース、それ以外はAPIから取得
   const parsedMemoData = useMemo<MemoDetailResponse | null>(() => {
-    if (memoData) {
-      try {
-        const parsed: FormatMemoResponse = JSON.parse(memoData);
+    if (!memoData) return null;
+
+    try {
+      const parsed = JSON.parse(memoData) as MemoDetailResponse | FormatMemoResponse;
+
+      if ('processingTimeMillis' in parsed) {
         return {
           memoId: parsed.memoId,
           title: parsed.title,
@@ -56,15 +60,18 @@ export function NoteDetailScreen() {
           // リアルタイム文字起こしではtranscriptionTextは使用しない
           // (showTranscription=falseで表示されないため、undefinedで問題なし)
           transcriptionText: undefined,
-          transcriptionStatus: 'COMPLETED', // ストリーミング文字起こし完了済み
+          transcriptionStatus: 'COMPLETED',
           formattingStatus: parsed.formattingStatus,
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
         };
-      } catch (e) {
-        if (__DEV__) console.error('Failed to parse memoData:', e);
-        return null;
       }
+
+      if ('transcriptionStatus' in parsed) {
+        return parsed;
+      }
+    } catch (e) {
+      if (__DEV__) console.error('Failed to parse memoData:', e);
     }
     return null;
   }, [memoData]);
@@ -82,14 +89,60 @@ export function NoteDetailScreen() {
   const [localTitle, setLocalTitle] = useState('');
   const [localContent, setLocalContent] = useState('');
 
+  // タブ状態
+  const [activeTab, setActiveTab] = useState<'memo' | 'transcription'>('memo');
+
+  // 文字起こし編集状態
+  const [transcriptionText, setTranscriptionText] = useState('');
+  const [initialTranscriptionText, setInitialTranscriptionText] = useState('');
+  const [isTranscriptionDirty, setIsTranscriptionDirty] = useState(false);
+  const [isTranscriptionLoading, setIsTranscriptionLoading] = useState(false);
+  const [hasFetchedTranscription, setHasFetchedTranscription] = useState(false);
+  const [isDiscardDialogVisible, setIsDiscardDialogVisible] = useState(false);
+  const pendingNavigationActionRef = useRef<any>(null);
+
+  const processingStatus = useProcessingStore((state) => state.status);
+  const startResummarize = useProcessingStore((state) => state.startResummarize);
+
   // メモが取得できたら初期化
   useEffect(() => {
     if (memo) {
       setLocalTags(memo.tags);
       setLocalTitle(memo.title || '');
       setLocalContent(memo.content || '');
+      const initialTranscript = memo.transcriptionText || '';
+      setTranscriptionText(initialTranscript);
+      setInitialTranscriptionText(initialTranscript);
+      setIsTranscriptionDirty(false);
+      setHasFetchedTranscription(Boolean(memo.transcriptionText));
     }
   }, [memo]);
+
+  const loadTranscription = useCallback(async () => {
+    if (!memo || hasFetchedTranscription || isTranscriptionLoading) {
+      return;
+    }
+
+    setIsTranscriptionLoading(true);
+    try {
+      const result = await apiClient.getTranscription(memo.memoId);
+      setTranscriptionText(result.transcription);
+      setInitialTranscriptionText(result.transcription);
+      setIsTranscriptionDirty(false);
+      setHasFetchedTranscription(true);
+    } catch (err) {
+      if (__DEV__) console.error('Failed to load transcription:', err);
+      Alert.alert('エラー', '文字起こしの取得に失敗しました');
+    } finally {
+      setIsTranscriptionLoading(false);
+    }
+  }, [memo, hasFetchedTranscription, isTranscriptionLoading]);
+
+  useEffect(() => {
+    if (activeTab === 'transcription') {
+      loadTranscription();
+    }
+  }, [activeTab, loadTranscription]);
 
   // タイトル保存処理（再試行機能付き）
   const handleSaveTitle = useCallback(
@@ -186,25 +239,13 @@ export function NoteDetailScreen() {
   });
 
   // 画面を離れる前に未保存の変更をflush
-  useEffect(() => {
-    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
-      // すでに保存処理中であれば、これ以上ブロックせず遷移を許可する
-      if (isSavingOnLeave) {
-        return;
-      }
-
-      // 未保存の変更がない場合は、そのまま遷移を許可する
-      if (!isDirtyTitle && !isDirtyContent) {
-        return;
-      }
-
-      // 未保存の変更がある場合は、画面遷移を一時停止して保存を完了させる
-      e.preventDefault();
+  const attemptLeaveWithSave = useCallback(
+    (action: any) => {
       setIsSavingOnLeave(true);
-
       Promise.all([flushTitle(), flushContent()])
         .then(() => {
-          navigation.dispatch(e.data.action);
+          setIsSavingOnLeave(false);
+          navigation.dispatch(action);
         })
         .catch((error) => {
           if (__DEV__) {
@@ -226,15 +267,49 @@ export function NoteDetailScreen() {
                 style: 'destructive',
                 onPress: () => {
                   setIsSavingOnLeave(false);
-                  navigation.dispatch(e.data.action);
+                  navigation.dispatch(action);
                 },
               },
             ]
           );
         });
+    },
+    [flushTitle, flushContent, navigation]
+  );
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      // すでに保存処理中であれば、これ以上ブロックせず遷移を許可する
+      if (isSavingOnLeave) {
+        return;
+      }
+
+      if (activeTab === 'transcription' && isTranscriptionDirty) {
+        e.preventDefault();
+        pendingNavigationActionRef.current = e.data.action;
+        setIsDiscardDialogVisible(true);
+        return;
+      }
+
+      // 未保存の変更がない場合は、そのまま遷移を許可する
+      if (!isDirtyTitle && !isDirtyContent) {
+        return;
+      }
+
+      // 未保存の変更がある場合は、画面遷移を一時停止して保存を完了させる
+      e.preventDefault();
+      attemptLeaveWithSave(e.data.action);
     });
     return unsubscribe;
-  }, [navigation, flushTitle, flushContent, isSavingOnLeave, isDirtyTitle, isDirtyContent]);
+  }, [
+    navigation,
+    attemptLeaveWithSave,
+    isSavingOnLeave,
+    isDirtyTitle,
+    isDirtyContent,
+    activeTab,
+    isTranscriptionDirty,
+  ]);
 
   // 削除処理
   const handleDelete = useCallback(async () => {
@@ -301,6 +376,52 @@ export function NoteDetailScreen() {
     }
   };
 
+  const handleTabPress = (tab: 'memo' | 'transcription') => {
+    if (tab === activeTab) return;
+
+    if (tab === 'memo' && activeTab === 'transcription' && isTranscriptionDirty) {
+      setTranscriptionText(initialTranscriptionText);
+      setIsTranscriptionDirty(false);
+    }
+
+    setActiveTab(tab);
+  };
+
+  const handleTranscriptionChange = useCallback(
+    (value: string) => {
+      setTranscriptionText(value);
+      setIsTranscriptionDirty(value !== initialTranscriptionText);
+    },
+    [initialTranscriptionText]
+  );
+
+  const handleConfirmResummarize = () => {
+    if (!memo) return;
+    if (!transcriptionText.trim()) {
+      Alert.alert('エラー', '文字起こしが空です');
+      return;
+    }
+
+    startResummarize(memo.memoId, transcriptionText);
+    router.replace('/home');
+  };
+
+  const handleDiscardTranscription = () => {
+    setIsDiscardDialogVisible(false);
+    setTranscriptionText(initialTranscriptionText);
+    setIsTranscriptionDirty(false);
+
+    const pendingAction = pendingNavigationActionRef.current;
+    pendingNavigationActionRef.current = null;
+    if (pendingAction) {
+      if (!isDirtyTitle && !isDirtyContent) {
+        navigation.dispatch(pendingAction);
+      } else {
+        attemptLeaveWithSave(pendingAction);
+      }
+    }
+  };
+
   // ローディング状態
   if (isLoading && !parsedMemoData) {
     return (
@@ -350,43 +471,106 @@ export function NoteDetailScreen() {
         }}
         keyboardShouldPersistTaps="handled"
       >
-        {/* タイトル（編集可能） */}
-        <EditableTitle value={localTitle} onChange={setLocalTitle} onBlur={flushTitle} />
-
-        {/* メタ情報 */}
-        <View className="mb-4">
-          {/* フォルダ情報 */}
-          {memo.folder && (
-            <View className="flex-row items-center gap-1 mb-1">
-              <MaterialCommunityIcons
-                name="folder-outline"
-                size={16}
-                color={colors.text.secondary}
-              />
-              <Text variant="bodyMedium" className="text-t-text-secondary">
-                {memo.folder.path}
-              </Text>
-            </View>
-          )}
-
-          {/* 日時 */}
-          <Text variant="bodySmall" className="text-t-text-tertiary">
-            {formatDate(memo.updatedAt)}
-          </Text>
+        {/* タブ切り替え */}
+        <View style={styles.tabsContainer}>
+          <TouchableOpacity
+            style={[styles.tabButton, activeTab === 'memo' && styles.tabButtonActive]}
+            onPress={() => handleTabPress('memo')}
+            accessibilityRole="button"
+            accessibilityLabel="メモタブ"
+          >
+            <Text style={[styles.tabText, activeTab === 'memo' && styles.tabTextActive]}>メモ</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.tabButton, activeTab === 'transcription' && styles.tabButtonActive]}
+            onPress={() => handleTabPress('transcription')}
+            accessibilityRole="button"
+            accessibilityLabel="文字起こしタブ"
+          >
+            <Text style={[styles.tabText, activeTab === 'transcription' && styles.tabTextActive]}>
+              文字起こし
+            </Text>
+          </TouchableOpacity>
         </View>
 
-        {/* タグ一覧 */}
-        <TagSection tags={localTags} onAddTag={handleAddTag} onRemoveTag={handleRemoveTag} />
+        {activeTab === 'memo' ? (
+          <>
+            {/* タイトル（編集可能） */}
+            <EditableTitle value={localTitle} onChange={setLocalTitle} onBlur={flushTitle} />
 
-        {/* 本文（編集可能） */}
-        <NoteContent
-          value={localContent}
-          onChange={setLocalContent}
-          onBlur={flushContent}
-          transcription={memo.transcriptionText}
-          showTranscription={false}
-          editable
-        />
+            {/* メタ情報 */}
+            <View className="mb-4">
+              {/* フォルダ情報 */}
+              {memo.folder && (
+                <View className="flex-row items-center gap-1 mb-1">
+                  <MaterialCommunityIcons
+                    name="folder-outline"
+                    size={16}
+                    color={colors.text.secondary}
+                  />
+                  <Text variant="bodyMedium" className="text-t-text-secondary">
+                    {memo.folder.path}
+                  </Text>
+                </View>
+              )}
+
+              {/* 日時 */}
+              <Text variant="bodySmall" className="text-t-text-tertiary">
+                {formatDate(memo.updatedAt)}
+              </Text>
+            </View>
+
+            {/* タグ一覧 */}
+            <TagSection tags={localTags} onAddTag={handleAddTag} onRemoveTag={handleRemoveTag} />
+
+            {/* 本文（編集可能） */}
+            <NoteContent
+              value={localContent}
+              onChange={setLocalContent}
+              onBlur={flushContent}
+              transcription={memo.transcriptionText}
+              showTranscription={false}
+              editable
+            />
+          </>
+        ) : (
+          <View>
+            <View style={styles.transcriptionCard}>
+              {isTranscriptionLoading ? (
+                <View style={styles.transcriptionLoading}>
+                  <ActivityIndicator size="small" color={colors.brand[500]} />
+                  <Text variant="bodySmall" className="text-t-text-tertiary">
+                    文字起こしを読み込み中...
+                  </Text>
+                </View>
+              ) : (
+                <TextInput
+                  value={transcriptionText}
+                  onChangeText={handleTranscriptionChange}
+                  multiline
+                  placeholder="文字起こしを編集できます"
+                  placeholderTextColor={colors.text.tertiary}
+                  style={styles.transcriptionInput}
+                  accessibilityLabel="文字起こしテキスト"
+                  accessibilityHint="文字起こし内容を編集します"
+                />
+              )}
+            </View>
+            <Text style={styles.transcriptionHint}>
+              誤字を修正して「確定」を押すと、AI整形を再実行します。
+            </Text>
+            <Button
+              mode="contained"
+              style={styles.actionButton}
+              contentStyle={styles.actionButtonContent}
+              labelStyle={styles.actionButtonLabel}
+              onPress={handleConfirmResummarize}
+              disabled={!isTranscriptionDirty || processingStatus === 'processing'}
+            >
+              確定してAI整形
+            </Button>
+          </View>
+        )}
       </ScrollView>
 
       {/* 削除確認ダイアログ */}
@@ -400,6 +584,84 @@ export function NoteDetailScreen() {
         onCancel={() => setIsDeleteDialogVisible(false)}
         variant="danger"
       />
+
+      <ConfirmDialog
+        visible={isDiscardDialogVisible}
+        title="変更を破棄しますか？"
+        message="編集した文字起こしの変更は失われます。"
+        confirmText="破棄する"
+        cancelText="キャンセル"
+        onConfirm={handleDiscardTranscription}
+        onCancel={() => setIsDiscardDialogVisible(false)}
+        variant="warning"
+      />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  tabsContainer: {
+    flexDirection: 'row',
+    backgroundColor: colors.bg.primary,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border.primary,
+    padding: 4,
+    marginBottom: 16,
+  },
+  tabButton: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderRadius: 10,
+  },
+  tabButtonActive: {
+    backgroundColor: colors.brand[600],
+  },
+  tabText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.text.secondary,
+  },
+  tabTextActive: {
+    color: colors.text.inverse,
+  },
+  transcriptionCard: {
+    backgroundColor: colors.bg.primary,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border.primary,
+    padding: 12,
+    minHeight: 240,
+  },
+  transcriptionInput: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: colors.text.primary,
+    textAlignVertical: 'top',
+    minHeight: 200,
+    padding: 0,
+  },
+  transcriptionLoading: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  transcriptionHint: {
+    marginTop: 8,
+    fontSize: 12,
+    color: colors.text.tertiary,
+  },
+  actionButton: {
+    marginTop: 16,
+    borderRadius: 10,
+  },
+  actionButtonContent: {
+    height: 44,
+  },
+  actionButtonLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/src/features/notes/NoteDetailScreen.tsx
+++ b/src/features/notes/NoteDetailScreen.tsx
@@ -32,9 +32,10 @@ function formatDate(isoString: string) {
 export function NoteDetailScreen() {
   const navigation = useNavigation();
   const headerHeight = useHeaderHeight();
-  const { id, memoData } = useLocalSearchParams<{
+  const { id, memoData, fromProcessing } = useLocalSearchParams<{
     id: string;
     memoData?: string;
+    fromProcessing?: string;
   }>();
 
   // 削除確認ダイアログの状態
@@ -330,6 +331,29 @@ export function NoteDetailScreen() {
   // ヘッダーの設定
   useLayoutEffect(() => {
     navigation.setOptions({
+      headerLeft: () => (
+        <TouchableOpacity
+          onPress={() => {
+            if (fromProcessing === '1') {
+              router.replace('/home');
+              return;
+            }
+            if (navigation.canGoBack()) {
+              router.back();
+            } else {
+              router.replace('/home');
+            }
+          }}
+          className="flex-row items-center px-3 py-2"
+          accessibilityRole="button"
+          accessibilityLabel="戻る"
+        >
+          <MaterialCommunityIcons name="chevron-left" size={22} color={colors.text.primary} />
+          <Text variant="bodyMedium" style={{ color: colors.text.primary, marginLeft: 2 }}>
+            戻る
+          </Text>
+        </TouchableOpacity>
+      ),
       headerRight: () => (
         <View className="flex-row items-center">
           {/* 削除ボタン */}

--- a/src/features/notes/NoteDetailScreen.tsx
+++ b/src/features/notes/NoteDetailScreen.tsx
@@ -90,9 +90,6 @@ export function NoteDetailScreen() {
   const [localTitle, setLocalTitle] = useState('');
   const [localContent, setLocalContent] = useState('');
 
-  // タブ状態
-  const [activeTab, setActiveTab] = useState<'memo' | 'transcription'>('memo');
-
   // 文字起こし編集状態
   const [transcriptionText, setTranscriptionText] = useState('');
   const [initialTranscriptionText, setInitialTranscriptionText] = useState('');
@@ -100,6 +97,7 @@ export function NoteDetailScreen() {
   const [isTranscriptionLoading, setIsTranscriptionLoading] = useState(false);
   const [hasFetchedTranscription, setHasFetchedTranscription] = useState(false);
   const [isDiscardDialogVisible, setIsDiscardDialogVisible] = useState(false);
+  const [isTranscriptionOpen, setIsTranscriptionOpen] = useState(false);
   const pendingNavigationActionRef = useRef<any>(null);
 
   const processingStatus = useProcessingStore((state) => state.status);
@@ -140,15 +138,18 @@ export function NoteDetailScreen() {
   }, [memo, hasFetchedTranscription, isTranscriptionLoading]);
 
   useEffect(() => {
-    if (activeTab === 'transcription') {
+    if (memo && isTranscriptionOpen) {
       loadTranscription();
     }
-  }, [activeTab, loadTranscription]);
+  }, [memo, isTranscriptionOpen, loadTranscription]);
 
   // タイトル保存処理（再試行機能付き）
   const handleSaveTitle = useCallback(
     async (newTitle: string) => {
       if (!memo) return;
+      if (newTitle.trim() === '') {
+        return;
+      }
 
       const attemptSave = async (): Promise<void> => {
         try {
@@ -188,6 +189,9 @@ export function NoteDetailScreen() {
   const handleSaveContent = useCallback(
     async (newContent: string) => {
       if (!memo) return;
+      if (newContent.trim() === '') {
+        return;
+      }
 
       const attemptSave = async (): Promise<void> => {
         try {
@@ -285,7 +289,7 @@ export function NoteDetailScreen() {
         return;
       }
 
-      if (activeTab === 'transcription' && isTranscriptionDirty) {
+      if (isTranscriptionDirty) {
         e.preventDefault();
         pendingNavigationActionRef.current = e.data.action;
         setIsDiscardDialogVisible(true);
@@ -308,7 +312,6 @@ export function NoteDetailScreen() {
     isSavingOnLeave,
     isDirtyTitle,
     isDirtyContent,
-    activeTab,
     isTranscriptionDirty,
   ]);
 
@@ -400,17 +403,6 @@ export function NoteDetailScreen() {
     }
   };
 
-  const handleTabPress = (tab: 'memo' | 'transcription') => {
-    if (tab === activeTab) return;
-
-    if (tab === 'memo' && activeTab === 'transcription' && isTranscriptionDirty) {
-      setTranscriptionText(initialTranscriptionText);
-      setIsTranscriptionDirty(false);
-    }
-
-    setActiveTab(tab);
-  };
-
   const handleTranscriptionChange = useCallback(
     (value: string) => {
       setTranscriptionText(value);
@@ -418,6 +410,15 @@ export function NoteDetailScreen() {
     },
     [initialTranscriptionText]
   );
+
+  const transcriptionLineHeight = 24;
+  const transcriptionPadding = 12;
+  const transcriptionLineCount = useMemo(
+    () => transcriptionText.split('\n').length,
+    [transcriptionText]
+  );
+  const transcriptionHeight =
+    Math.max(1, transcriptionLineCount) * transcriptionLineHeight + transcriptionPadding * 2;
 
   const handleConfirmResummarize = () => {
     if (!memo) return;
@@ -487,114 +488,150 @@ export function NoteDetailScreen() {
   return (
     <View className="flex-1 bg-t-bg-secondary">
       <ScrollView
-        className="flex-1"
+        className="flex-1 bg-t-bg-secondary"
         contentContainerStyle={{
           paddingHorizontal: 16,
-          paddingTop: headerHeight,
+          paddingTop: headerHeight + 16,
           paddingBottom: 32,
         }}
         keyboardShouldPersistTaps="handled"
       >
-        {/* タブ切り替え */}
-        <View style={styles.tabsContainer}>
-          <TouchableOpacity
-            style={[styles.tabButton, activeTab === 'memo' && styles.tabButtonActive]}
-            onPress={() => handleTabPress('memo')}
-            accessibilityRole="button"
-            accessibilityLabel="メモタブ"
-          >
-            <Text style={[styles.tabText, activeTab === 'memo' && styles.tabTextActive]}>メモ</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.tabButton, activeTab === 'transcription' && styles.tabButtonActive]}
-            onPress={() => handleTabPress('transcription')}
-            accessibilityRole="button"
-            accessibilityLabel="文字起こしタブ"
-          >
-            <Text style={[styles.tabText, activeTab === 'transcription' && styles.tabTextActive]}>
-              文字起こし
-            </Text>
-          </TouchableOpacity>
-        </View>
+        <View className="w-full max-w-[1200px] mx-auto">
+          <View className="flex flex-col gap-6 md:flex-row md:gap-8 md:items-start">
+            <View className="flex-1 md:flex-[6] md:pr-2">
+              {/* タイトル（編集可能） */}
+              <EditableTitle value={localTitle} onChange={setLocalTitle} onBlur={flushTitle} />
 
-        {activeTab === 'memo' ? (
-          <>
-            {/* タイトル（編集可能） */}
-            <EditableTitle value={localTitle} onChange={setLocalTitle} onBlur={flushTitle} />
+              {/* メタ情報 */}
+              <View className="mb-4">
+                {/* フォルダ情報 */}
+                {memo.folder && (
+                  <View className="flex-row items-center gap-1 mb-1">
+                    <MaterialCommunityIcons
+                      name="folder-outline"
+                      size={16}
+                      color={colors.text.secondary}
+                    />
+                    <Text
+                      variant="bodyMedium"
+                      className="text-t-text-secondary"
+                      style={{ color: colors.text.secondary }}
+                    >
+                      {memo.folder.path}
+                    </Text>
+                  </View>
+                )}
 
-            {/* メタ情報 */}
-            <View className="mb-4">
-              {/* フォルダ情報 */}
-              {memo.folder && (
-                <View className="flex-row items-center gap-1 mb-1">
-                  <MaterialCommunityIcons
-                    name="folder-outline"
-                    size={16}
-                    color={colors.text.secondary}
-                  />
-                  <Text variant="bodyMedium" className="text-t-text-secondary">
-                    {memo.folder.path}
-                  </Text>
+                {/* 日時 */}
+                <Text
+                  variant="bodySmall"
+                  className="text-t-text-tertiary"
+                  style={{ color: colors.text.tertiary }}
+                >
+                  {formatDate(memo.updatedAt)}
+                </Text>
+              </View>
+
+              {/* タグ一覧 */}
+              <TagSection tags={localTags} onAddTag={handleAddTag} onRemoveTag={handleRemoveTag} />
+
+              {/* 本文（編集可能） */}
+              <NoteContent
+                value={localContent}
+                onChange={setLocalContent}
+                onBlur={flushContent}
+                transcription={memo.transcriptionText}
+                showTranscription={false}
+                editable
+              />
+              {!isTranscriptionOpen && (
+                <View className="mt-4">
+                  <Button
+                    mode="outlined"
+                    style={styles.secondaryButton}
+                    contentStyle={styles.secondaryButtonContent}
+                    labelStyle={styles.secondaryButtonLabel}
+                    onPress={() => setIsTranscriptionOpen(true)}
+                    textColor={colors.text.primary}
+                  >
+                    文字起こしを開く
+                  </Button>
                 </View>
               )}
-
-              {/* 日時 */}
-              <Text variant="bodySmall" className="text-t-text-tertiary">
-                {formatDate(memo.updatedAt)}
-              </Text>
             </View>
 
-            {/* タグ一覧 */}
-            <TagSection tags={localTags} onAddTag={handleAddTag} onRemoveTag={handleRemoveTag} />
-
-            {/* 本文（編集可能） */}
-            <NoteContent
-              value={localContent}
-              onChange={setLocalContent}
-              onBlur={flushContent}
-              transcription={memo.transcriptionText}
-              showTranscription={false}
-              editable
-            />
-          </>
-        ) : (
-          <View>
-            <View style={styles.transcriptionCard}>
-              {isTranscriptionLoading ? (
-                <View style={styles.transcriptionLoading}>
-                  <ActivityIndicator size="small" color={colors.brand[500]} />
-                  <Text variant="bodySmall" className="text-t-text-tertiary">
-                    文字起こしを読み込み中...
+            {isTranscriptionOpen && (
+              <View className="flex-1 md:flex-[4] md:pl-2">
+                <View className="flex-row items-center justify-between mb-2">
+                  <Text
+                    variant="titleSmall"
+                    className="text-t-text-primary"
+                    style={{ color: colors.text.primary }}
+                  >
+                    文字起こし
                   </Text>
+                  <TouchableOpacity
+                    onPress={() => setIsTranscriptionOpen(false)}
+                    className="flex-row items-center px-2 py-1"
+                    accessibilityRole="button"
+                    accessibilityLabel="文字起こしを閉じる"
+                  >
+                    <Text variant="bodySmall" style={{ color: colors.text.secondary }}>
+                      閉じる
+                    </Text>
+                  </TouchableOpacity>
                 </View>
-              ) : (
-                <TextInput
-                  value={transcriptionText}
-                  onChangeText={handleTranscriptionChange}
-                  multiline
-                  placeholder="文字起こしを編集できます"
-                  placeholderTextColor={colors.text.tertiary}
-                  style={styles.transcriptionInput}
-                  accessibilityLabel="文字起こしテキスト"
-                  accessibilityHint="文字起こし内容を編集します"
-                />
-              )}
-            </View>
-            <Text style={styles.transcriptionHint}>
-              誤字を修正して「確定」を押すと、AI整形を再実行します。
-            </Text>
-            <Button
-              mode="contained"
-              style={styles.actionButton}
-              contentStyle={styles.actionButtonContent}
-              labelStyle={styles.actionButtonLabel}
-              onPress={handleConfirmResummarize}
-              disabled={!isTranscriptionDirty || processingStatus === 'processing'}
-            >
-              確定してAI整形
-            </Button>
+                <View className="bg-t-bg-primary border border-t-border-primary rounded-xl p-1">
+                  {isTranscriptionLoading ? (
+                    <View style={styles.transcriptionLoading}>
+                      <ActivityIndicator size="small" color={colors.brand[500]} />
+                      <Text
+                        variant="bodySmall"
+                        className="text-t-text-tertiary"
+                        style={{ color: colors.text.tertiary }}
+                      >
+                        文字起こしを読み込み中...
+                      </Text>
+                    </View>
+                  ) : (
+                    <TextInput
+                      value={transcriptionText}
+                      onChangeText={handleTranscriptionChange}
+                      multiline
+                      placeholder="文字起こしを編集できます"
+                      placeholderTextColor={colors.text.tertiary}
+                      style={[
+                        styles.transcriptionInput,
+                        {
+                          height: transcriptionHeight,
+                          lineHeight: transcriptionLineHeight,
+                          padding: transcriptionPadding,
+                        },
+                      ]}
+                      className="text-base leading-6 md:text-[17px] md:leading-[26px]"
+                      accessibilityLabel="文字起こしテキスト"
+                      accessibilityHint="文字起こし内容を編集します"
+                    />
+                  )}
+                </View>
+                <View className="mt-3 md:items-end">
+                  <Button
+                    mode="contained"
+                    style={styles.actionButton}
+                    contentStyle={styles.actionButtonContent}
+                    labelStyle={styles.actionButtonLabel}
+                    onPress={handleConfirmResummarize}
+                    disabled={processingStatus === 'processing'}
+                    buttonColor={colors.brand[600]}
+                    textColor={colors.text.inverse}
+                  >
+                    AIで再整形
+                  </Button>
+                </View>
+              </View>
+            )}
           </View>
-        )}
+        </View>
       </ScrollView>
 
       {/* 削除確認ダイアログ */}
@@ -624,47 +661,9 @@ export function NoteDetailScreen() {
 }
 
 const styles = StyleSheet.create({
-  tabsContainer: {
-    flexDirection: 'row',
-    backgroundColor: colors.bg.primary,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: colors.border.primary,
-    padding: 4,
-    marginBottom: 16,
-  },
-  tabButton: {
-    flex: 1,
-    alignItems: 'center',
-    paddingVertical: 8,
-    borderRadius: 10,
-  },
-  tabButtonActive: {
-    backgroundColor: colors.brand[600],
-  },
-  tabText: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: colors.text.secondary,
-  },
-  tabTextActive: {
-    color: colors.text.inverse,
-  },
-  transcriptionCard: {
-    backgroundColor: colors.bg.primary,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: colors.border.primary,
-    padding: 12,
-    minHeight: 240,
-  },
   transcriptionInput: {
-    fontSize: 16,
-    lineHeight: 24,
     color: colors.text.primary,
     textAlignVertical: 'top',
-    minHeight: 200,
-    padding: 0,
   },
   transcriptionLoading: {
     flex: 1,
@@ -672,14 +671,21 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     gap: 8,
   },
-  transcriptionHint: {
-    marginTop: 8,
-    fontSize: 12,
-    color: colors.text.tertiary,
-  },
   actionButton: {
-    marginTop: 16,
+    marginTop: 12,
     borderRadius: 10,
+  },
+  secondaryButton: {
+    borderRadius: 10,
+    borderColor: colors.border.primary,
+    width: '100%',
+  },
+  secondaryButtonContent: {
+    height: 40,
+  },
+  secondaryButtonLabel: {
+    fontSize: 14,
+    fontWeight: '600',
   },
   actionButtonContent: {
     height: 44,

--- a/src/features/notes/note-content/MarkdownEditor.tsx
+++ b/src/features/notes/note-content/MarkdownEditor.tsx
@@ -1,5 +1,5 @@
 import { colors } from '@/src/shared/constants';
-import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
 import { TextInput } from 'react-native';
 
 interface MarkdownEditorProps {
@@ -18,6 +18,10 @@ export interface MarkdownEditorRef {
 export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>(
   ({ value, onChangeText, onBlur, placeholder, autoFocus }, ref) => {
     const inputRef = useRef<TextInput>(null);
+    const lineHeight = 24;
+    const verticalPadding = 12;
+    const lineCount = useMemo(() => value.split('\n').length, [value]);
+    const editorHeight = Math.max(1, lineCount) * lineHeight + verticalPadding * 2;
 
     useImperativeHandle(ref, () => ({
       focus: () => inputRef.current?.focus(),
@@ -37,13 +41,12 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         accessibilityLabel="メモの本文"
         accessibilityHint="メモの内容を入力してください"
         style={{
-          flex: 1,
           fontSize: 16,
-          lineHeight: 24,
+          lineHeight,
           color: colors.text.primary,
-          minHeight: 200,
+          height: editorHeight,
           textAlignVertical: 'top',
-          padding: 12,
+          padding: verticalPadding,
         }}
       />
     );

--- a/src/features/notes/note-content/MarkdownEditor.tsx
+++ b/src/features/notes/note-content/MarkdownEditor.tsx
@@ -20,8 +20,12 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     const inputRef = useRef<TextInput>(null);
     const lineHeight = 24;
     const verticalPadding = 12;
+    const minEditorHeight = 200;
     const lineCount = useMemo(() => value.split('\n').length, [value]);
-    const editorHeight = Math.max(1, lineCount) * lineHeight + verticalPadding * 2;
+    const editorHeight = Math.max(
+      minEditorHeight,
+      Math.max(1, lineCount) * lineHeight + verticalPadding * 2
+    );
 
     useImperativeHandle(ref, () => ({
       focus: () => inputRef.current?.focus(),

--- a/src/features/notes/note-content/NoteContent.tsx
+++ b/src/features/notes/note-content/NoteContent.tsx
@@ -116,8 +116,6 @@ export function NoteContent({
   if (isEditing && editable) {
     return (
       <Surface className="bg-t-bg-primary rounded-xl p-1" elevation={0}>
-        {/* 表示モードの鉛筆アイコン行と同じ高さのスペーサー */}
-        <View className="flex-row items-center justify-end px-2 pt-1 h-5" />
         <MarkdownEditor
           ref={editorRef}
           value={value}
@@ -139,10 +137,10 @@ export function NoteContent({
       accessibilityRole={editable ? 'button' : undefined}
       accessibilityLabel={editable ? 'メモを編集' : undefined}
     >
-      <Surface className="bg-t-bg-primary rounded-xl p-1" elevation={0}>
+      <Surface className="bg-t-bg-primary rounded-xl p-1 relative" elevation={0}>
         {/* 編集可能ヒント */}
         {editable && (
-          <View className="flex-row items-center justify-end px-2 pt-1">
+          <View className="absolute right-3 top-2">
             <MaterialCommunityIcons
               name="pencil-outline"
               size={14}
@@ -152,13 +150,15 @@ export function NoteContent({
           </View>
         )}
 
-        {showTranscription && transcription ? (
-          <Text className="text-t-text-primary text-base leading-6 p-2">{transcription}</Text>
-        ) : (
-          <Markdown style={markdownStyles} markdownit={markdownItInstance} rules={customRules}>
-            {value || 'メモをタップして編集...'}
-          </Markdown>
-        )}
+        <View style={{ padding: 12 }}>
+          {showTranscription && transcription ? (
+            <Text className="text-t-text-primary text-base leading-6">{transcription}</Text>
+          ) : (
+            <Markdown style={markdownStyles} markdownit={markdownItInstance} rules={customRules}>
+              {value || 'メモをタップして編集...'}
+            </Markdown>
+          )}
+        </View>
       </Surface>
     </TouchableOpacity>
   );

--- a/src/features/notes/note-tags/TagSection.tsx
+++ b/src/features/notes/note-tags/TagSection.tsx
@@ -28,6 +28,7 @@ export function TagSection({ tags, onAddTag, onRemoveTag }: TagSectionProps) {
     <Pressable
       onPress={handleSectionPress}
       style={styles.container}
+      className="w-full"
       accessibilityLabel="タグセクション"
     >
       {/* アイコン */}

--- a/src/features/notes/note-title/EditableTitle.tsx
+++ b/src/features/notes/note-title/EditableTitle.tsx
@@ -63,6 +63,7 @@ export function EditableTitle({ value, onChange, onBlur }: EditableTitleProps) {
       <Text
         variant="titleLarge"
         className="font-semibold text-t-text-primary flex-1"
+        style={{ color: colors.text.primary }}
         numberOfLines={2}
       >
         {displayTitle}

--- a/src/navigation/screen-options.tsx
+++ b/src/navigation/screen-options.tsx
@@ -1,3 +1,4 @@
+import { colors } from '@/src/shared/constants';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { HeaderButton } from '@react-navigation/elements';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
@@ -94,9 +95,8 @@ export const noteDetailScreenOptions: NativeStackNavigationOptions = {
   title: '',
   headerTransparent: true,
   headerStyle: {
-    backgroundColor: 'transparent',
+    backgroundColor: colors.bg.secondary,
   },
-  headerBlurEffect: undefined,
 };
 
 /**

--- a/src/navigation/screen-options.tsx
+++ b/src/navigation/screen-options.tsx
@@ -6,7 +6,6 @@ import { router } from 'expo-router';
 import { Linking, Pressable, Text, View } from 'react-native';
 
 import { SettingsMenu } from '@/src/shared/components';
-import { colors } from '@/src/shared/constants';
 
 const FEEDBACK_FORM_URL = 'https://forms.gle/PXkrsrkpikbKXHUk6';
 

--- a/src/shared/components/ProcessingToast.tsx
+++ b/src/shared/components/ProcessingToast.tsx
@@ -20,6 +20,7 @@ export function ProcessingToast() {
   // 処理状態を取得
   const status = useProcessingStore((state) => state.status);
   const memoResult = useProcessingStore((state) => state.memoResult);
+  const actionType = useProcessingStore((state) => state.actionType);
   const retry = useProcessingStore((state) => state.retry);
   const dismissBanner = useProcessingStore((state) => state.dismissBanner);
 
@@ -142,6 +143,7 @@ export function ProcessingToast() {
         params: {
           id: memoResult.memoId,
           memoData: JSON.stringify(memoResult),
+          fromProcessing: actionType === 'resummarize' ? '1' : undefined,
         },
       });
     } else {

--- a/src/shared/stores/processingStore.ts
+++ b/src/shared/stores/processingStore.ts
@@ -115,6 +115,15 @@ export const useProcessingStore = create<ProcessingState>()((set, get) => ({
       return;
     }
 
+    if (actionType === 'resummarize' && !memoId) {
+      set({
+        status: 'error',
+        memoResult: null,
+        error: 'メモIDが不足しているため再試行できません',
+      });
+      return;
+    }
+
     set({
       status: 'processing',
       memoResult: null,
@@ -124,7 +133,7 @@ export const useProcessingStore = create<ProcessingState>()((set, get) => ({
     try {
       const result =
         actionType === 'resummarize'
-          ? await apiClient.resummarizeMemo(memoId ?? '', transcript)
+          ? await apiClient.resummarizeMemo(memoId!, transcript)
           : await apiClient.formatMemo(transcript, language ?? 'ja-JP');
 
       set({

--- a/src/shared/stores/processingStore.ts
+++ b/src/shared/stores/processingStore.ts
@@ -1,5 +1,5 @@
-import type { FormatMemoResponse } from '@/src/api/generated/apiSchema';
 import { apiClient } from '@/src/api';
+import type { FormatMemoResponse, MemoDetailResponse } from '@/src/api/generated/apiSchema';
 import { create } from 'zustand';
 
 export type ProcessingStatus = 'idle' | 'processing' | 'completed' | 'error';
@@ -7,15 +7,18 @@ export type ProcessingStatus = 'idle' | 'processing' | 'completed' | 'error';
 interface ProcessingState {
   // 状態
   status: ProcessingStatus;
-  memoResult: FormatMemoResponse | null;
+  memoResult: MemoDetailResponse | FormatMemoResponse | null;
   error: string | null;
   transcript: string | null;
   language: string | null;
+  memoId: string | null;
+  actionType: 'format' | 'resummarize' | null;
 
   // アクション
   startProcessing: (transcript: string, language?: string) => Promise<void>;
+  startResummarize: (memoId: string, editedTranscription: string) => Promise<void>;
   retry: () => Promise<void>;
-  setCompleted: (result: FormatMemoResponse) => void;
+  setCompleted: (result: MemoDetailResponse | FormatMemoResponse) => void;
   setError: (error: string) => void;
   reset: () => void;
   dismissBanner: () => void;
@@ -28,6 +31,8 @@ export const useProcessingStore = create<ProcessingState>()((set, get) => ({
   error: null,
   transcript: null,
   language: null,
+  memoId: null,
+  actionType: null,
 
   // 処理開始（バックグラウンドでAPI呼び出し）
   startProcessing: async (transcript: string, language = 'ja-JP') => {
@@ -42,6 +47,8 @@ export const useProcessingStore = create<ProcessingState>()((set, get) => ({
       error: null,
       transcript,
       language,
+      memoId: null,
+      actionType: 'format',
     });
 
     try {
@@ -65,10 +72,46 @@ export const useProcessingStore = create<ProcessingState>()((set, get) => ({
     }
   },
 
+  // 再AI整形を開始（編集済み文字起こし）
+  startResummarize: async (memoId: string, editedTranscription: string) => {
+    if (get().status === 'processing') {
+      return;
+    }
+
+    set({
+      status: 'processing',
+      memoResult: null,
+      error: null,
+      transcript: editedTranscription,
+      language: null,
+      memoId,
+      actionType: 'resummarize',
+    });
+
+    try {
+      const result = await apiClient.resummarizeMemo(memoId, editedTranscription);
+
+      set({
+        status: 'completed',
+        memoResult: result,
+        error: null,
+      });
+    } catch (err) {
+      if (__DEV__) console.error('Failed to resummarize memo:', err);
+      const errorMessage = err instanceof Error ? err.message : '処理に失敗しました';
+
+      set({
+        status: 'error',
+        memoResult: null,
+        error: errorMessage,
+      });
+    }
+  },
+
   // 再試行
   retry: async () => {
-    const { transcript, language } = get();
-    if (!transcript) {
+    const { transcript, language, actionType, memoId } = get();
+    if (!transcript || !actionType) {
       return;
     }
 
@@ -79,7 +122,10 @@ export const useProcessingStore = create<ProcessingState>()((set, get) => ({
     });
 
     try {
-      const result = await apiClient.formatMemo(transcript, language ?? 'ja-JP');
+      const result =
+        actionType === 'resummarize'
+          ? await apiClient.resummarizeMemo(memoId ?? '', transcript)
+          : await apiClient.formatMemo(transcript, language ?? 'ja-JP');
 
       set({
         status: 'completed',
@@ -87,7 +133,7 @@ export const useProcessingStore = create<ProcessingState>()((set, get) => ({
         error: null,
       });
     } catch (err) {
-      if (__DEV__) console.error('Failed to format memo (retry):', err);
+      if (__DEV__) console.error('Failed to process memo (retry):', err);
       const errorMessage = err instanceof Error ? err.message : '処理に失敗しました';
 
       set({
@@ -99,7 +145,7 @@ export const useProcessingStore = create<ProcessingState>()((set, get) => ({
   },
 
   // 処理完了（手動設定用）
-  setCompleted: (result: FormatMemoResponse) => {
+  setCompleted: (result: MemoDetailResponse | FormatMemoResponse) => {
     set({
       status: 'completed',
       memoResult: result,
@@ -124,6 +170,8 @@ export const useProcessingStore = create<ProcessingState>()((set, get) => ({
       error: null,
       transcript: null,
       language: null,
+      memoId: null,
+      actionType: null,
     });
   },
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npx expo export --platform web",
+  "outputDirectory": "dist",
+  "framework": null
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "installCommand": "npm install --legacy-peer-deps",
   "buildCommand": "npx expo export --platform web",
   "outputDirectory": "dist",
-  "framework": null
+  "framework": null,
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "npm install --legacy-peer-deps",
   "buildCommand": "npx expo export --platform web",
   "outputDirectory": "dist",
   "framework": null


### PR DESCRIPTION
## 関連 Issue

Closes #80

## やったこと
- 編集画面で「文字起こし」タブのUI実装
- 文字起こし内容の編集機能
- 再AI整形APIとの連携
- AI整形中のトースト通知（ホーム画面）

## 追加したライブラリ、パッケージ

## 動作確認

- [x] ビルドできた
<img width="1470" height="956" alt="スクリーンショット 2026-02-08 12 34 04" src="https://github.com/user-attachments/assets/033274f9-2de9-43f7-b9db-7d53076fa3c5" />
<img width="1470" height="956" alt="スクリーンショット 2026-02-08 12 34 07" src="https://github.com/user-attachments/assets/95022209-9f55-41f8-b8bc-3cccd5a970c3" />


## 参考にした資料

<!-- I want to review in Japanese. -->
<!-- 日本語でレビューしてください -->

#### レビューの接頭語

[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報
